### PR TITLE
Ignore invalid SemVer tags when using `semver` strategy

### DIFF
--- a/lib/strategies/semver.js
+++ b/lib/strategies/semver.js
@@ -42,7 +42,9 @@ var semverStrategy = {
       .map(function(tagName) {
         return tagPrefix.strip(tagName);
       })
-      .filter(semver.valid)
+      .filter(function(tagName) {
+        return semver.valid(tagName);
+      })
       .sort(semver.compare)
       .reverse();
 

--- a/tests/acceptance/commands/release-nodetest.js
+++ b/tests/acceptance/commands/release-nodetest.js
@@ -211,6 +211,33 @@ describe("release command", function() {
             repo.respondTo('status', makeResponder(''));
           });
 
+          describe("when an invalid semver tag exists", function() {
+            var invalidTag = {
+              name: 'v6.0.990.1',
+              sha: '7a6d7bb7e5beb1bce2923dd6aea82f8a8e77438b',
+              date: new Date(Date.UTC(2013, 1, 15, 15, 0, 0))
+            };
+
+            beforeEach(function() {
+              tags.splice(1, 0, invalidTag);
+              repo.respondTo('tags', makeResponder(tags));
+            });
+
+            it("should ignore invalid tags", function() {
+              var cmd = createCommand();
+
+              repo.respondTo('createTag', makeResponder(null));
+
+              return cmd.validateAndRun([ '--local', '--yes' ]).then(function() {
+                expect(ui.output).to.contain("Latest tag: " + tags[tags.length - 1].name);
+              });
+            });
+
+            afterEach(function() {
+              tags.splice(1, 1);
+            });
+          });
+
           it("should confirm tag creation and allow aborting", function() {
             var cmd = createCommand();
 

--- a/tests/unit/strategies/semver-nodetest.js
+++ b/tests/unit/strategies/semver-nodetest.js
@@ -7,7 +7,7 @@ var expect = require('chai').expect;
 var semverStrategy = require('../../../lib/strategies/semver');
 
 describe("semver strategy", function() {
-  var tagNames = [ '2.0.0', '2.1.0', '3.0.0', '3.0.1', '3.1.0', '3.1.1' ];
+  var tagNames = [ '2.0.0', '2.1.0', '3.0.0', '3.0.1', '3.1.0', '3.1.1', 'v6.0.990.1' ];
   var project = {};
 
   it("should provide a default tag", function() {


### PR DESCRIPTION
The documentation does not imply that invalid Semver tags should result
in a crash when using the `semver` strategy, but merely that these tags
should be ignored:

> Find the latest tag that is SemVer compliant and increment its PATCH
> version

This fix simply ensures that only valid semver tags are considered. This
was not the case because there are 3 parameters provided to the
`Array.filter` callback, the second being an int representing the index
of the element being filtered. The problem is that the `semver.valid`
function accepts two parameters and if the second is truthy, it will use
the `LOOSE` regex to validate the version, which may yield unwanted
results.